### PR TITLE
FIX : 프로바이더들이 정의되지 않은 리소스를 넘길때

### DIFF
--- a/src/main/java/me/devksh930/oembed/client/OembedClient.java
+++ b/src/main/java/me/devksh930/oembed/client/OembedClient.java
@@ -1,7 +1,7 @@
 package me.devksh930.oembed.client;
 
 import lombok.RequiredArgsConstructor;
-import me.devksh930.oembed.dto.OembedDto;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -9,6 +9,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -24,12 +26,13 @@ public class OembedClient {
                 .build();
     }
 
-    public OembedDto getOembedResource(String url, String apiUrl) {
+    public Map<String, Object> getOembedResource(String url, String apiUrl) {
         URI reqeustURL = UriComponentsBuilder.fromHttpUrl(apiUrl)
-                .queryParam("format", "json")
+//                .queryParam("format", "json")
                 .queryParam("url", url).encode().build().toUri();
 
-        ResponseEntity<OembedDto> exchange = restTemplate.exchange(requestEntity(reqeustURL), OembedDto.class);
+        ResponseEntity<HashMap<String, Object>> exchange = restTemplate.exchange(requestEntity(reqeustURL), new ParameterizedTypeReference<>() {
+        });
         return exchange.getBody();
     }
 

--- a/src/main/java/me/devksh930/oembed/controller/OembedRestController.java
+++ b/src/main/java/me/devksh930/oembed/controller/OembedRestController.java
@@ -2,7 +2,6 @@ package me.devksh930.oembed.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.devksh930.oembed.dto.EndpointsDto;
-import me.devksh930.oembed.dto.OembedDto;
 import me.devksh930.oembed.service.OembedProviderService;
 import me.devksh930.oembed.service.OembedService;
 import org.springframework.http.HttpStatus;
@@ -12,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
 import java.util.List;
 
 @RestController
@@ -27,8 +27,8 @@ public class OembedRestController {
     }
 
     @GetMapping
-    public ResponseEntity<OembedDto> getOembedResource(@RequestParam("url") String url) {
-        OembedDto oembedResource = oembedService.getOembedResource(url.trim());
+    public ResponseEntity<HashMap<String, Object>> getOembedResource(@RequestParam("url") String url) {
+        HashMap<String, Object> oembedResource = (HashMap<String, Object>) oembedService.getOembedResource(url.trim());
         return new ResponseEntity<>(oembedResource, HttpStatus.OK);
     }
 

--- a/src/main/java/me/devksh930/oembed/service/OembedService.java
+++ b/src/main/java/me/devksh930/oembed/service/OembedService.java
@@ -3,8 +3,9 @@ package me.devksh930.oembed.service;
 import lombok.RequiredArgsConstructor;
 import me.devksh930.oembed.client.OembedClient;
 import me.devksh930.oembed.dto.EndpointsDto;
-import me.devksh930.oembed.dto.OembedDto;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -12,7 +13,7 @@ public class OembedService {
     private final OembedProviderService oembedProviderService;
     private final OembedClient oembedClient;
 
-    public OembedDto getOembedResource(String url) {
+    public Map<String, Object> getOembedResource(String url) {
         EndpointsDto byUrlPathMatching = oembedProviderService.findByUrlPathMatching(url);
         return oembedClient.getOembedResource(url, byUrlPathMatching.getUrl());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ oembed:
 
 logging:
   level:
-    root: info
+    root: debug
     me:
       devksh930:
         oembed:


### PR DESCRIPTION
# Summary

- 일부 프로바이더들이 공식문서에 있는 속성 외에 더 많은 정보를 보내는 경우가 있음.

# Details

- 데이터를 받아올때 OembedDto.java를 이용 하는것 보다  HashMap을 이용해서 받아오도록 변경
### 기존코드
```java
        ResponseEntity<OembedDto> exchange = restTemplate.exchange(requestEntity(reqeustURL), OembedDto.class);
```
### 변경한 코드
```java
     ResponseEntity<HashMap<String, Object>> exchange = restTemplate.exchange(requestEntity(reqeustURL), new ParameterizedTypeReference<>() {
        });
```