### PR TITLE
인스타그램과 페이스북 지원을 위한 기능 추가함

### DIFF
--- a/src/main/java/me/devksh930/oembed/client/OembedClient.java
+++ b/src/main/java/me/devksh930/oembed/client/OembedClient.java
@@ -1,6 +1,8 @@
 package me.devksh930.oembed.client;
 
 import lombok.RequiredArgsConstructor;
+import me.devksh930.oembed.exception.ClientForbiddenException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +22,38 @@ public class OembedClient {
     private final RestTemplate restTemplate;
 
 
+    @Value("${oembed.facebook.accessToken}")
+    private String facebookAccessToken;
+    @Value("${oembed.instagram.accessToken}")
+    private String instagramAccessToken;
+
     private RequestEntity<Void> requestEntity(URI uri) {
         return RequestEntity
                 .get(uri)
                 .build();
     }
 
-    public Map<String, Object> getOembedResource(String url, String apiUrl) {
-        URI reqeustURL = UriComponentsBuilder.fromHttpUrl(apiUrl)
-//                .queryParam("format", "json")
-                .queryParam("url", url).encode().build().toUri();
+    private URI makeUri(String url, String apiUrl) {
+        UriComponentsBuilder requestURLBuilder = UriComponentsBuilder.fromHttpUrl(apiUrl)
+                .queryParam("url", url)
+                .queryParam("format", "json");
+        URI requestURL;
 
-        ResponseEntity<HashMap<String, Object>> exchange = restTemplate.exchange(requestEntity(reqeustURL), new ParameterizedTypeReference<>() {
+        if (apiUrl.contains("instagram") || apiUrl.contains("facebook")) {
+            throw new ClientForbiddenException("권한 문제로 지원하지 않는 URL입니다");
+//            requestURL = requestURLBuilder
+//                    .queryParam("access_token", instagramAccessToken).encode().build().toUri();
+
+        } else {
+            requestURL = requestURLBuilder
+                    .encode().build().toUri();
+        }
+        return requestURL;
+    }
+
+    public Map<String, Object> getOembedResource(String url, String apiUrl) {
+
+        ResponseEntity<HashMap<String, Object>> exchange = restTemplate.exchange(requestEntity(makeUri(url, apiUrl)), new ParameterizedTypeReference<>() {
         });
         return exchange.getBody();
     }


### PR DESCRIPTION
# Summary
- 인스타그램과 Facebook API는 private로 전환되었다
- AccesToken 발급이 힘들어 추후 기능을 지원 하도록₩
# Details

```java
    private URI makeUri(String url, String apiUrl) {
        UriComponentsBuilder requestURLBuilder = UriComponentsBuilder.fromHttpUrl(apiUrl)
                .queryParam("url", url)
                .queryParam("format", "json");
        URI requestURL;

        if (apiUrl.contains("instagram") || apiUrl.contains("facebook")) {
            throw new ClientForbiddenException("권한 문제로 지원하지 않는 URL입니다");
//            requestURL = requestURLBuilder
//                    .queryParam("access_token", instagramAccessToken).encode().build().toUri();

        } else {
            requestURL = requestURLBuilder
                    .encode().build().toUri();
        }
        return requestURL;
    }
```
- 임시로 Exception을 던짐
- private한 API를 호출하기 위한 AccessToken을 파라미터로 추가하는 부분을 임시로 주석처리함