### PR TITLE
Provider리스트를 불러오는 API캐싱

### DIFF
--- a/src/main/java/me/devksh930/oembed/client/OembedProviderClient.java
+++ b/src/main/java/me/devksh930/oembed/client/OembedProviderClient.java
@@ -3,6 +3,7 @@ package me.devksh930.oembed.client;
 import lombok.RequiredArgsConstructor;
 import me.devksh930.oembed.dto.OembedProviderDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.*;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Service;
@@ -22,7 +23,7 @@ public class OembedProviderClient {
     @Value("${oembed.providerListUrl}")
     private String OEMBED_PROVIDER_URL;
 
-
+    @Cacheable(cacheNames = "allEndPoint")
     public List<OembedProviderDto> getProvider() {
 
         restTemplate.getInterceptors().add((request, body, execution) -> {

--- a/src/main/java/me/devksh930/oembed/common/TimeTraceAop.java
+++ b/src/main/java/me/devksh930/oembed/common/TimeTraceAop.java
@@ -14,14 +14,14 @@ public class TimeTraceAop {
     @Around("execution(* me.devksh930.oembed..*(..))")
     public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
         long start = System.currentTimeMillis();
-        log.debug("Start: " + joinPoint.toString());
+        log.info("Start: " + joinPoint.toString());
         try {
 
             return joinPoint.proceed();
         } finally {
             long finish = System.currentTimeMillis();
             long timeMs = finish - start;
-            log.debug("End: " + joinPoint.toString() + " " + timeMs + "ms");
+            log.info("End: " + joinPoint.toString() + " " + timeMs + "ms");
         }
     }
 }

--- a/src/main/java/me/devksh930/oembed/common/config/CacheConfig.java
+++ b/src/main/java/me/devksh930/oembed/common/config/CacheConfig.java
@@ -1,0 +1,31 @@
+package me.devksh930.oembed.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableCaching
+@EnableScheduling
+@Slf4j
+public class CacheConfig {
+    public static final String PROVIDER_ENDPOINT_LIST = "allEndPoint";
+
+    @Bean
+    public CacheManager cacheManager() {
+        ConcurrentMapCacheManager cacheManager = new ConcurrentMapCacheManager(PROVIDER_ENDPOINT_LIST);
+        return cacheManager;
+    }
+
+    @CacheEvict(allEntries = true, value = {PROVIDER_ENDPOINT_LIST})
+    @Scheduled(fixedDelay = 3 * 60 * 1000, initialDelay = 3000)
+    public void cacheEvict() {
+        log.debug("캐쉬 삭제");
+    }
+}

--- a/src/main/java/me/devksh930/oembed/common/config/CacheConfig.java
+++ b/src/main/java/me/devksh930/oembed/common/config/CacheConfig.java
@@ -24,7 +24,7 @@ public class CacheConfig {
     }
 
     @CacheEvict(allEntries = true, value = {PROVIDER_ENDPOINT_LIST})
-    @Scheduled(fixedDelay = 3 * 60 * 1000, initialDelay = 3000)
+    @Scheduled(fixedDelay = 3 * 60 * 60 * 1000, initialDelay = 3000)
     public void cacheEvict() {
         log.debug("캐쉬 삭제");
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,8 +7,8 @@ oembed:
 
 logging:
   level:
-    root: debug
+    root: info
     me:
       devksh930:
         oembed:
-          contorller: debug
+          contorller: info


### PR DESCRIPTION
# 성능 측정
![image](https://user-images.githubusercontent.com/45715241/149674279-b4984943-42c9-4cf0-9b59-c94f09c59075.png)
- AOP를 이용해 모든 메서드들의 속도를 측정 해보았다
- 현재 문제점은 OembedProviderClient의 요청시간이 오래걸린다는 점이다.
- 해당 API를 캐싱하기로 했다


# Provider List를 불러오는 API 캐싱
- 캐시를 지원하는 `EhCache` , `Jcache`, `Redis` 등이 존재 한다. 하지만 간단하게 해결하기 위해 Spring에서 기본적으로 지원하는 기능을 사용했다.(실제로 프로덕션환경에서 쓰기는 부적합하다 함.)
- 삭제는 스케쥴러를 통해서 3시간간격으로 `@CacheEvict`를 실행하도록 했다


# 결과

### 캐싱 되기 전
<img width="854" alt="스크린샷 2022-01-17 오전 4 21 49" src="https://user-images.githubusercontent.com/45715241/149674646-ea0965cb-f296-426d-958e-8df8bb34b086.png">

### 캐싱 되고 나서
![image](https://user-images.githubusercontent.com/45715241/149674687-37db6d81-03ad-4a13-93dd-e86fe8ad7fc0.png)

- 캐싱 되기 전에는 전과 비슷한 속도가 나오지만 캐싱이 한번만 되고 나면 엄청 빠른 속도로 API를 호출한다